### PR TITLE
Allow WVI app to be run via Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Start from a Shiny Server container from the Rocker Project
+# https://rocker-project.org/
+FROM rocker/shiny:4.2.0
+
+# Install necessary Ubuntu software packages
+RUN apt-get update && apt-get install -y \
+    libcurl4-gnutls-dev \
+    libssl-dev \
+    git-core \
+    libxml2-dev \
+    nano
+# NOTE: nano is there for looking at logs
+
+# Install necessary R packages
+RUN R -e 'install.packages(c(\
+        "shiny", \
+        "shinydashboard", \
+        "shinyjs", \
+        "magrittr", \
+        "DT", \
+        "rjson", \
+        "tidyverse", \
+        "wordcloud", \
+        "ggrepel", \
+        "devtools" \
+      ), \
+      repos="https://packagemanager.rstudio.com/cran/__linux__/focal/2022-09-14"\
+    ); \
+    library("devtools"); \
+    devtools::install_github("bmschmidt/wordVectors")'
+
+# Copy application into Docker image
+COPY ./ /srv/shiny-server/wvi/
+
+# Use a modified Shiny Server configuration
+COPY ./docker/shiny-server.conf /etc/shiny-server/
+
+USER shiny
+
+# Run app
+CMD ["/usr/bin/shiny-server"]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ With the required libraries present, you can simply open `app.R`, and select the
 *I haven’t done this part myself, but [the instructions](http://shiny.rstudio.com/articles/shinyapps.html) seem pretty straightforward.*-->
 
 
+### Running a local copy with Docker
+
+The Word Vector Interface can be run in a self-contained Docker environment. We recommend against using this option locally—the RStudio method is easier to customize and often quicker to set up.
+
+However, Docker environments have the benefit of being easily reproducible. You might have to wait longer for the Word Vector Interface to start up, but it *should* start, with all prerequisites taken care of for you. If you’re struggling with running the app in RStudio, try the [instructions for running the app with Docker](./docker/README.md).
+
+
 ## Customizing the application
 
 When run, the Word Vector Interface will read in models from the “data” folder, and make them available for querying. Models are only published, however, if (1) they have a corresponding entry in the catalog [“data/catalog.json”](https://github.com/NEU-DSG/word-vector-interface/blob/main/data/catalog.json), and (2) that entry is marked “public”.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update && apt-get install -y \
     git-core \
     libxml2-dev \
     nano
-# NOTE: nano is there for looking at logs
 
 # Install necessary R packages
+# NOTE: By using the "repos" parameter option, the R packages are version-locked to 
+#   those available on a certain date.
 RUN R -e 'install.packages(c(\
         "shiny", \
         "shinydashboard", \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN R -e 'install.packages(c(\
     devtools::install_github("bmschmidt/wordVectors")'
 
 # Copy application into Docker image
-COPY ./ /srv/shiny-server/wvi/
+COPY --chown=shiny ./ /srv/shiny-server/wvi/
 
 # Use a modified Shiny Server configuration
 COPY ./docker/shiny-server.conf /etc/shiny-server/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
 # Start from a Shiny Server container from the Rocker Project
-# https://rocker-project.org/
 FROM rocker/shiny:4.2.0
 
 # Install necessary Ubuntu software packages

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,7 +42,13 @@ Once the build process is complete, you can start up a Docker container by runni
 docker run -p 3838:3838 wvi
 ```
 
-When you see a line that reads “[INFO] shiny-server - Starting listener on http://[::]:3838”, you can visit <localhost:3838> to start the process of initializing the Shiny app.
+When you see a line that looks like this: 
+
+```
+[INFO] shiny-server - Starting listener on http://[::]:3838
+```
+
+...you can visit [localhost:3838](http://localhost:3838). The page will fail to load, but you’ll have told the Shiny Server to start loading the Word Vector Interface and the word2vec models.
 
 As mentioned earlier, the process of loading all the models takes a very long time, much longer than the app takes when run through RStudio. Unfortunately, there’s no easy way to tell how far along the process is. You can check for progress by refreshing the page, or [use Docker to enter the container's command line interface](https://docs.docker.com/desktop/use-desktop/container/#integrated-terminal) and view the logs.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,8 +39,10 @@ Building the image will take some time, but once you have the image, you probabl
 Once the build process is complete, you can start up a Docker container by running this command:
 
 ```
-docker run -p 3838:3838 wvi
+docker run -p 3838:3838 --name=shiny-app wvi
 ```
+
+This command tells Docker to use the "wvi" image to generate and run a container named "shiny-app". Docker will map the container's port 3838 to your computer's port 3838, letting you visit the application in the browser.
 
 When you see a line that looks like this: 
 
@@ -52,12 +54,41 @@ When you see a line that looks like this:
 
 As mentioned earlier, the process of loading all the models takes a very long time, much longer than the app takes when run through RStudio. Unfortunately, there’s no easy way to tell how far along the process is. You can check for progress by refreshing the page, or [use Docker to enter the container's command line interface](https://docs.docker.com/desktop/use-desktop/container/#integrated-terminal) and view the logs.
 
+To stop the application, hit the <kbd>Control</kbd> and <kbd>c</kbd> keys while inside the Terminal window where the Docker container is running.
+
 
 ### Inside the Docker container
 
-Here are the main points of interest within the Docker container environment:
+Here's how to enter the Docker container command line interface through the Terminal:
+
+```
+docker exec -it shiny-app /bin/sh
+```
+
+The main points of interest within the Docker container environment are:
 
 * Shiny Server config: `/etc/shiny-server/shiny-server.conf`
 * Log files: `/var/log/shiny-server/`
 * Apps directory: `/srv/shiny-server/`
   * Word Vector Interface: `/srv/shiny-server/wvi/`
+
+The Docker container has the `nano` editor installed for reading and editing files via the command line.
+
+
+## Troubleshooting
+
+### Memory problems
+
+If you see this line soon after starting the Docker container:
+
+```
+[INFO] shiny-server - Error getting worker: Error: The application exited during initialization.
+```
+
+...the Shiny app may have run out of memory as it tried to load all the "public" word vector models. If it's not possible to switch to a computer with more RAM available, you can find out how much memory is available by running this command:
+
+```
+docker info
+```
+
+You can probably still run the application, but you should [edit the catalog](../components.md#word-embedding-models) so that fewer models need to be loaded.

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ As part of this process, Docker follows the instructions given in [the WVI Docke
 * copies the code into the right place;
 * and sets up a [custom Shiny Server configuration file](./shiny-server.conf).
 
-Building the image will take some time, but once you have the image, you probably won't need to rebuild it very often. If you make changes to the R code, Dockerfile, or models, just rerun the steps above.
+Building the image will take some time, but once you have the image, you probably won't need to rebuild it very often. If you make changes to the R code, Dockerfile, or models, see the section on [updating the Docker image](#updating-the-docker-image).
 
 
 ## Start the application
@@ -56,6 +56,12 @@ As mentioned earlier, the process of loading all the models takes a very long ti
 
 To stop the application, hit the <kbd>Control</kbd> and <kbd>c</kbd> keys while inside the Terminal window where the Docker container is running.
 
+To restart the "shiny-app" Docker container, you can run this command:
+
+```
+docker restart shiny-app
+```
+
 
 ### Inside the Docker container
 
@@ -70,9 +76,25 @@ The main points of interest within the Docker container environment are:
 * Shiny Server config: `/etc/shiny-server/shiny-server.conf`
 * Log files: `/var/log/shiny-server/`
 * Apps directory: `/srv/shiny-server/`
-  * Word Vector Interface: `/srv/shiny-server/wvi/`
+  * Word Vector Interface code: `/srv/shiny-server/wvi/`
 
-The Docker container has the `nano` editor installed for reading and editing files via the command line.
+To read or edit files inside the Docker container, use the `nano` editor.
+
+
+## Updating the Docker image
+
+Once you’ve made changes to the R Shiny code, catalog file, or models, you’ll need to rebuild the "wvi" Docker image so that your changes are reflected. As before, navigate to the `word-vector-interface` folder and run this command:
+
+```
+docker build --file docker/Dockerfile --tag wvi .
+```
+
+To run the Shiny app Docker container, you’ll first have to delete the old one, then tell Docker to start up a new container with the same name:
+
+```
+docker rm shiny-app
+docker run -p 3838:3838 --name=shiny-app wvi
+```
 
 
 ## Troubleshooting

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,57 @@
+# Running the Word Vector Interface with Docker
+
+The Word Vector Interface can be run in a Docker image, using the files contained in the `docker/` directory. This method is useful for reproducing the app in a working environment, without a lot of fiddly installation work.
+
+It is not a fast option, however: models take *much* longer to load when the Shiny app is run this way. You may have to wait up to an hour for the application to finish initializing.
+
+You will need:
+
+* some familiarity with the command line;
+* [Docker](https://docs.docker.com/get-docker/); and
+* [a copy of the Word Vector Interface repository](https://github.com/NEU-DSG/word-vector-interface/releases).
+
+
+## Build the Docker image
+
+First, you’ll need to [build a Docker image](https://docs.docker.com/engine/reference/builder/). Using the command line, navigate to the main directory which contains the Shiny app code, for example:
+
+```
+cd /Users/aclark/Documents/word-vector-interface
+```
+
+Then, instruct Docker to use the `Dockerfile` in this folder to construct an image with the name "wvi":
+
+```
+docker build --file docker/Dockerfile --tag wvi .
+```
+
+As part of this process, Docker follows the instructions given in [the WVI Dockerfile](./Dockerfile). We start with a pre-built [Shiny Server](https://www.rstudio.com/products/shiny/shiny-server/) Docker container from [The Rocker Project](https://rocker-project.org/). From there, Docker:
+
+* installs software and R libraries;
+* copies the code into the right place;
+* and sets up a [custom Shiny Server configuration file](./shiny-server.conf).
+
+Building the image will take some time, but once you have the image, you probably won't need to rebuild it very often. If you make changes to the R code, Dockerfile, or models, just rerun the steps above.
+
+
+## Start the application
+
+Once the build process is complete, you can start up a Docker container by running this command:
+
+```
+docker run -p 3838:3838 wvi
+```
+
+When you see a line that reads “[INFO] shiny-server - Starting listener on http://[::]:3838”, you can visit <localhost:3838> to start the process of initializing the Shiny app.
+
+As mentioned earlier, the process of loading all the models takes a very long time, much longer than the app takes when run through RStudio. Unfortunately, there’s no easy way to tell how far along the process is. You can check for progress by refreshing the page, or [use Docker to enter the container's command line interface](https://docs.docker.com/desktop/use-desktop/container/#integrated-terminal) and view the logs.
+
+
+### Inside the Docker container
+
+Here are the main points of interest within the Docker container environment:
+
+* Shiny Server config: `/etc/shiny-server/shiny-server.conf`
+* Log files: `/var/log/shiny-server/`
+* Apps directory: `/srv/shiny-server/`
+  * Word Vector Interface: `/srv/shiny-server/wvi/`

--- a/docker/shiny-server.conf
+++ b/docker/shiny-server.conf
@@ -1,5 +1,8 @@
 # Instruct Shiny Server to run applications as the user "shiny"
 run_as shiny;
+    
+# Preserve logs from exited processes
+preserve_logs true;
 
 # Define a server that listens on port 3838
 server {
@@ -22,8 +25,5 @@ server {
 
     # Define location for Shiny logs
     log_dir /var/log/shiny-server;
-    
-    # Preserve logs from exited processes
-    preserve_logs true;
   }
 }

--- a/docker/shiny-server.conf
+++ b/docker/shiny-server.conf
@@ -10,14 +10,17 @@ server {
 
     # Host the Word Vector Interface Shiny app
     app_dir /srv/shiny-server/wvi;
+    
     # Increase the initialization period, allowing models to load
     app_init_timeout 2000000;
+    
     # Don't kill the R process, even when idle
     app_idle_timeout 0;
-    # Enforce using WebSockets to connect to the app.
+    
+    # Enforce using WebSockets to connect to the app
     disable_websockets off;
 
-    # Log all Shiny output to files in this directory
+    # Define location for Shiny logs
     log_dir /var/log/shiny-server;
   }
 }

--- a/docker/shiny-server.conf
+++ b/docker/shiny-server.conf
@@ -22,5 +22,8 @@ server {
 
     # Define location for Shiny logs
     log_dir /var/log/shiny-server;
+    
+    # Preserve logs from exited processes
+    preserve_logs true;
   }
 }

--- a/docker/shiny-server.conf
+++ b/docker/shiny-server.conf
@@ -1,8 +1,10 @@
 # Instruct Shiny Server to run applications as the user "shiny"
 run_as shiny;
     
-# Preserve logs from exited processes
-preserve_logs true;
+# Do not preserve logs from processes that exited cleanly
+# NOTE: In local or development environments, it may be useful to preserve logs.
+# To do so, replace "false" with "true" in the line below.
+preserve_logs false;
 
 # Define a server that listens on port 3838
 server {

--- a/docker/shiny-server.conf
+++ b/docker/shiny-server.conf
@@ -1,0 +1,23 @@
+# Instruct Shiny Server to run applications as the user "shiny"
+run_as shiny;
+
+# Define a server that listens on port 3838
+server {
+  listen 3838;
+
+  # Define a location at the base URL
+  location / {
+
+    # Host the Word Vector Interface Shiny app
+    app_dir /srv/shiny-server/wvi;
+    # Increase the initialization period, allowing models to load
+    app_init_timeout 2000000;
+    # Don't kill the R process, even when idle
+    app_idle_timeout 0;
+    # Enforce using WebSockets to connect to the app.
+    disable_websockets off;
+
+    # Log all Shiny output to files in this directory
+    log_dir /var/log/shiny-server;
+  }
+}


### PR DESCRIPTION
The WVI Docker image is useful for publishing the app, but also for allowing people to run the WVI in a replicable environment.