### PR TITLE
Make it easier to generate a WVI release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test.R
 .DS_Store
 /testing/models
 /testing/output
+releases/**

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,35 @@
+<project
+   default="release" 
+   name="word-vector-interface">
+  
+  <!--
+    Apache Ant buildfile for generating a ZIP release of the Word Vector Interface.
+    -->
+  
+<!-- 
+    PROPERTIES
+  -->
+  <property name="build.dir" value="releases"/>
+  
+<!-- 
+    ANT TASKS
+  -->
+  
+  <!-- Create a ZIP file of the customizable WVI app. -->
+  <target name="release"
+          description="Create a ZIP file of the customizable WVI app.">
+    <mkdir dir="${build.dir}"/>
+    <zip destfile="${build.dir}/word-vector-interface_customizable.zip">
+      <!-- Artifacts of the Ant build are excluded from packaging, as are git artifacts. The models 
+        directory (`data/`) is skipped for now. -->
+      <fileset dir="." 
+        excludes="${build.dir}/** build.xml maintenance.md .git/** .gitignore data/** .DS_Store .Rproj.user/*"/>
+      <!-- Include only the models specified in data/catalog_mini.json . -->
+      <zipfileset dir="data" includes="README.md wwo.bin vwwp.bin vep-em1080.bin vep-ecco.bin"
+        prefix="data"/>
+      <!-- Replace the regular catalog file with the mini one. -->
+      <zipfileset dir="data" includes="catalog_mini.json" fullpath="data/catalog.json"/>
+    </zip>
+  </target>
+  
+</project>

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,9 @@
   <target name="release"
           description="Create a ZIP file of the customizable WVI app.">
     <mkdir dir="${build.dir}"/>
-    <zip destfile="${build.dir}/word-vector-interface_customizable.zip">
+    <!-- Prompt the user to provide an versioning string for the filename. -->
+    <input message="Input a version number to use in the ZIP filename:" addproperty="version"/>
+    <zip destfile="${build.dir}/word-vector-interface-${version}_customizable.zip">
       <!-- Artifacts of the Ant build are excluded from packaging, as are git artifacts. The models 
         directory (`data/`) is skipped for now. -->
       <fileset dir="." 

--- a/data/catalog_mini.json
+++ b/data/catalog_mini.json
@@ -1,23 +1,41 @@
 {
-
   "WWO Corpus": {
     "shortName": "WWO Full Corpus",
     "location": "data/wwo.bin",
-  	"shortDescription" : "All texts from WWO",
-  	"public" : "true",
-  	"date":"June 2019",
-  	"modelUrl": "https://github.com/NEU-DSG/word-vector-interface/blob/main/data/wwo.bin",
-    "description": "Currently displayed: the entire Women Writers Online corpus of women’s writing from 1526 to 1850. This corpus contains 10,978,553 words in 415 texts. This model was trained in June 2019."
+    "shortDescription": "All texts from WWO",
+    "public": "true",
+    "date": "December 2025",
+    "modelUrl": "https://github.com/NEU-DSG/word-vector-interface/blob/main/data/wwo.bin",
+    "description": "Currently displayed: the entire Women Writers Online corpus of women’s writing from 1526 to 1850. This corpus contains 12,818,063 words in 474 texts. This model was trained in December 2025."
   },
   
-    "WWO Regularized Corpus": {
-    "shortName": "WWO Regularized Full Corpus",
-    "location": "data/wwo-regularized.bin",
-  	"shortDescription" : "All texts from WWO, regularized",
-  	"public" : "true",
-  	"date":"February 2020",
-  	"modelUrl":"https://github.com/NEU-DSG/word-vector-interface/blob/main/data/wwo-regularized.bin",
-    "description": "Currently displayed: the entire Women Writers Online corpus of women’s writing from 1526 to 1850, regularized with routines developed by the Visualizing English Print project. This corpus contains 11,279,989 words in 421 texts. This model was trained in February 2020."
+  "VWWP": {
+    "shortName": "VWWP Full Corpus",
+    "location": "data/vwwp.bin",
+    "shortDescription": "The Victorian Women Writers Project Corpus",
+    "public": "true",
+    "date": "December 2025",
+    "modelUrl": "https://github.com/NEU-DSG/word-vector-interface/blob/main/data/vwwp.bin",
+    "description": "Currently displayed: the entire Victorian Women Writers Project corpus of women’s writing from 1830 to 1929. This corpus contains 7,992,386 words in 199 texts. This model was trained in December 2025."
+  },
+  
+  "VEP Early Modern 1080": {
+    "shortName": "VEP Early Modern 1080",
+    "location": "data/vep-em1080.bin",
+    "shortDescription": "Visualizing English Print project’s Early Modern 1080 corpus",
+    "public": "true",
+    "date": "December 2025",
+    "modelUrl": "https://github.com/NEU-DSG/word-vector-interface/tree/main/data/vep-em1080.bin",
+    "description": "Currently displayed: the Visualizing English Print project’s Early Modern 1080 corpus. The corpus includes 40 randomly selected texts per decade from the period 1530–1799. Texts were sourced from EEBO-TCP Phase I and ECCO-TCP. This corpus contains 37,088,017 words in 1080 texts. This model was trained in December 2025."
+  },
+  
+  "VEP ECCO": {
+    "shortName": "VEP ECCO",
+    "location": "data/vep-ecco.bin",
+    "shortDescription": "Visualizing English Print project’s Eighteenth Century Collections Online corpus",
+    "public": "true",
+    "date": "December 2025",
+    "modelUrl": "https://github.com/NEU-DSG/word-vector-interface/tree/main/data/vep-ecco.bin",
+    "description": "Currently displayed: the Visualizing English Print project’s Eighteenth Century Collections Online corpus. Texts were extracted from the ECCO-TCP XML files; the spellings are original and the corpus covers the period 1701–1800. This corpus contains 73,982,448 words in 2,473 texts. This model was trained in December 2025."
   }
-
 }

--- a/maintenance.md
+++ b/maintenance.md
@@ -6,7 +6,7 @@ As with other git repositories, in general work should be done in the `develop` 
 
 However, since the WWP uses this app for pedagogical purposes, we've set up other git branches. Here's a rundown:
 
-* `main`: The publication branch. The code from this branch runs at <lab.wwp.northeastern.edu>.
+* `main`: The publication branch. The code from this branch runs at <http://lab.wwp.northeastern.edu>.
 * `develop`: The branch used for development and testing. Changes to the Shiny app as a whole should be made here, and merged into the other branches when ready.
 * `experimentals-only`: This branch contains a subdirectory in the `data` folder, containing experimental models. The models are also listed in the catalog. This branch serves as the base for the event-specific branches.
 * Event-specific branches contain additional models which have been published in the WVI sandbox for pedagogical reasons. These branches are:
@@ -18,6 +18,47 @@ However, since the WWP uses this app for pedagogical purposes, we've set up othe
 ### Determining which models would be shown in the app
 
 Open the [model catalog](data/catalog.json) and search for the string `"public" : "true"`. (Regular expression: `"public"\s*:\s*"true"`.) The objects containing that key-value pair represent models that will be loaded when the Shiny app starts up.
+
+
+### Creating a release
+
+1. Check that the `data/catalog_mini.json` file is up-to-date with metadata from the standard `catalog.json`.
+    1. If not, copy the relevant entries from the standard file to the mini one.
+    2. Save and commit your changes to `develop`.
+    3. Either: open a PR to merge the changes into `main`, or use git commands to make the merge.
+2. Make sure you're on the `main` branch and you have all commits from GitHub.
+    1. `git checkout main`
+    2. `git pull`
+2. Create an [annotated git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags) for the last commit in this branch.
+    1. The tag name should be a [semantic version](https://en.wikipedia.org/wiki/Software_versioning), such as `v3.2`. Increment the minor version number unless the WVI app has seen significant changes.
+    2. For example: `git tag -a -m "Updated models and added testing script" v3.1`
+3. Push the tag to the GitHub repository.
+    1. `git push --tags origin`
+    2. Your new tag should now be listed on the repository's [Tags page](https://github.com/NEU-DSG/word-vector-interface/tags).
+5. Create a ZIP of the codebase for customization, using an Apache Ant build.
+    1. `ant`
+    2. You will be prompted for a versioning string. Use your new tag, e.g. `v3.2`.
+    3. (Optional.) Make sure you can run the customizable app.
+        1. Unzip the release.
+        2. Open the RStudio project file.
+        3. Run `app.R` as a Shiny app.
+        4. Make sure there are no errors in the startup, and the app runs as expected.
+5. [Draft a release in GitHub.](https://github.com/NEU-DSG/word-vector-interface/releases/new)
+    1. Select your new tag from the "Tag" dropdown.
+    2. For the release title, use "Word Vector Interface, YYYY-MM-DD" (with the current date).
+    3. Write a short description of significant updates. (A sample appears below.)
+    4. Click the button that says "Attach binaries".
+        1. Navigate to your ZIP file and select it.
+    6. Make sure "Set as the latest release" is checked.
+    7. Click the "Publish release" button.
+6. Trumpet the achievement!
+
+#### Sample release description
+
+Title: Word Vector Interface, 2026-01-20
+
+> This release includes a new "testing" directory and `Model-Testing-Template.Rmd`, a script for testing new models against several thousand pairs of words which we expect to have high similarity.
+> This release also provides updates to the models included in the customizable Word Vector Interface.
 
 
 ### Updating for an Institute or workshop


### PR DESCRIPTION
I added instructions to maintenance.md for creating a release of the customizable Word Vector Interface, and set up an Ant build file to zip up the directory to specifications.